### PR TITLE
Change model_id method to look up the model_id method using the class name (string) rather than the class itself

### DIFF
--- a/lib/indexed_search/index.rb
+++ b/lib/indexed_search/index.rb
@@ -113,7 +113,8 @@ module IndexedSearch
         IndexedSearch::Entry.where(:modelid => model_id)
       end
       def model_id
-        IndexedSearch::Index.models_by_id.invert[self]
+        #IndexedSearch::Index.models_by_id.invert[self] or (require 'debugger'; debugger )
+        IndexedSearch::Index.models_by_id.detect {|k,v| v.name == self.name }.first
       end
       
       # The column from your indexed model that will be stored in the Entry model's modelrowid attribute.


### PR DESCRIPTION
This fixes an annoying error that I keep running into in the development environment.
